### PR TITLE
ci: GitHub Actions の Node.js 20 非推奨警告を解消

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -15,13 +15,13 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 
       - name: Install asdf & tools
         uses: asdf-vm/actions/install@v4
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ap-northeast-1
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
## Summary

- CI の Node.js 20 非推奨警告を解消するため、`actions/checkout` を v5、`aws-actions/configure-aws-credentials` を v6 に更新しました
- アプリの Node 22（asdf）および Lambda の Node 22 ランタイムには変更はありません

## Test plan

- [ ] PR の `build-and-deploy` workflow が成功する
- [ ] 実行ログの Complete job に Node.js 20 非推奨警告が出ないこと


Made with [Cursor](https://cursor.com)